### PR TITLE
add find-any subcommand

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -29,6 +29,6 @@ jobs:
         python -m pip install --upgrade pip
         pip install pyflakes pycodestyle
     - name: check coding style
-      run: pycodestyle jsonfind
+      run: pycodestyle --max-line-length=120 jsonfind
     - name: pyflakes
       run: pyflakes jsonfind/[^_]*.py

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+    branches-ignore: [master, gh-pages]
+
+jobs:
+  style:
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: setup python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: get pip cache
+      id: pip-cache
+      run: |
+        python -c "from pip._internal.locations import USER_CACHE_DIR; print('::set-output name=dir::' + USER_CACHE_DIR)"
+    - name: cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key: ${{ runner.os }}-pip-${{ hashfiles('**/requirements.txt') }}
+        restore-keys: ${{ runner.os }}-pip-
+    - name: Install checker
+      run: |
+        python -m pip install --upgrade pip
+        pip install pyflakes pycodestyle
+    - name: check coding style
+      run: pycodestyle jsonfind
+    - name: pyflakes
+      run: pyflakes jsonfind/[^_]*.py

--- a/jsonfind/jsonfind.py
+++ b/jsonfind/jsonfind.py
@@ -6,7 +6,7 @@
 >>> JsonFind.to_jsonpath(JsonFind.find_eq(obj, tgt))
 'c'
 """
-
+import re
 from logging import getLogger
 import jsonpointer
 import jsonpath
@@ -22,7 +22,133 @@ except (ModuleNotFoundError, ImportError):
 log = getLogger(__name__)
 
 
+def EQ(a, b):
+    return a == b
+
+
+def IS(a, b):
+    return a is b
+
+
+def compare_regexp(a, b):
+    """
+    >>> compare_regexp("abcde", "bcd")
+    False
+    >>> compare_regexp("abcde", "a[bcd]{3}e")
+    True
+    >>> compare_regexp("a,bcde", "[abcde,]*")
+    True
+    >>> compare_regexp("abcde", re.compile("bcd[ef]"))
+    False
+    >>> compare_regexp({"b":"abcde"}, "bcd[ef]")
+    False
+    """
+    log.debug("compare(regexp) %s %s", a, b)
+    if isinstance(a, str):
+        if isinstance(b, re.Pattern):
+            return b.fullmatch(a) is not None
+        elif isinstance(b, str):
+            return re.fullmatch(b, a) is not None
+    return EQ(a, b)
+
+
+def compare_regexp_substr(a, b):
+    """
+    >>> compare_regexp_substr("abcde", "bcd")
+    True
+    >>> compare_regexp_substr("abcde", "bcdf")
+    False
+    >>> compare_regexp_substr("abcde", "bcd[ef]")
+    True
+    >>> compare_regexp_substr("abcde", re.compile("bcd[ef]"))
+    True
+    >>> compare_regexp_substr({"b":"abcde"}, "bcd[ef]")
+    False
+    """
+    if isinstance(a, str):
+        if isinstance(b, re.Pattern):
+            return b.search(a) is not None
+        elif isinstance(b, str):
+            return re.search(b, a) is not None
+    return EQ(a, b)
+
+
+def compare_subset(a, b, key_fn=EQ, val_fn=EQ):
+    """
+    >>> compare_subset({"a":"b", "c":{"d":"e"}}, {"a":"b"})
+    True
+    >>> compare_subset({"a":"b", "c":{"d":"e"}}, {"a":"c"})
+    False
+    >>> compare_subset({"a":"b", "c":{"d":"e"}}, {"a":"b", "c":"d"})
+    False
+    >>> compare_subset({"a":"b", "c":{"d":"e"}}, {})
+    True
+    >>> compare_subset([1,2,3], [1,3,5,2,4])
+    False
+    >>> compare_subset([1,2,3], [1,3])
+    True
+    """
+    if isinstance(b, (list, tuple)) and isinstance(a, (list, tuple)):
+        for ib in b:
+            if not any(compare_subset(ia, ib, key_fn, val_fn) for ia in a):
+                return False
+        return True
+    elif isinstance(b, dict) and isinstance(a, dict):
+        for kb, vb in b.items():
+            flag = False
+            for ka, va in filter(lambda f: key_fn(f[0], kb), a.items()):
+                if compare_subset(va, vb, key_fn, val_fn):
+                    flag = True
+                    break
+            if not flag:
+                return False
+        return True
+    return val_fn(a, b)
+
+
+def compare_superset(a, b, key_fn=EQ, val_fn=EQ):
+    """
+    >>> compare_superset({"a":"b", "c":{"d":"e"}}, {"a":"b", "c":{"d":"e", "f":"g"}})
+    True
+    >>> compare_superset({"a":"b", "c":{"d":"e"}}, {"a":"b"})
+    False
+    >>> compare_superset({"a":"b", "c":{"d":"e"}}, {"a":"b", "c":"d"})
+    False
+    >>> compare_superset({"a":"b", "c":{"d":"e"}}, {})
+    False
+    >>> compare_superset({"a":"b"}, {"a":"b"})
+    True
+    >>> compare_superset({"a":"b"}, {"a":"b", "c":"d"})
+    True
+    >>> compare_superset([1,2,3], [1,3,5,2,4])
+    True
+    >>> compare_superset([1,2,3], [1,3])
+    False
+    """
+    if isinstance(a, (list, tuple)) and isinstance(b, (list, tuple)):
+        for ia in a:
+            if not any(compare_superset(ia, ib, key_fn, val_fn) for ib in b):
+                return False
+        return True
+    elif isinstance(a, dict) and isinstance(b, dict):
+        for ka, va in a.items():
+            flag = False
+            for kb, vb in filter(lambda f: key_fn(ka, f[0]), b.items()):
+                if compare_superset(va, vb, key_fn, val_fn):
+                    flag = True
+                    break
+            if not flag:
+                return False
+        return True
+    return val_fn(a, b)
+
+
+def compare_set(a, b, key_fn=EQ, val_fn=EQ):
+    return compare_subset(a, b, key_fn, val_fn) and compare_superset(a, b, key_fn, val_fn)
+
+
 class JsonFind:
+
     @classmethod
     def get_children(cls, obj):
         if isinstance(obj, dict):
@@ -76,6 +202,42 @@ class JsonFind:
         return
 
     @classmethod
+    def filter_compare(cls, obj, target, key_fn=IS, val_fn=IS):
+        if compare_set(obj, target, key_fn, val_fn):
+            log.debug("found %s %s", obj, target)
+            yield []
+            return
+        log.debug("not-found %s %s", obj, target)
+        for k, v in cls.get_children(obj):
+            for chld in cls.filter_compare(v, target, key_fn, val_fn):
+                yield [k, *chld]
+        return
+
+    @classmethod
+    def filter_compare_subset(cls, obj, target, key_fn=IS, val_fn=IS):
+        if compare_subset(obj, target, key_fn, val_fn):
+            log.debug("found %s %s", obj, target)
+            yield []
+            return
+        log.debug("not-found %s %s", obj, target)
+        for k, v in cls.get_children(obj):
+            for chld in cls.filter_compare_subset(v, target, key_fn, val_fn):
+                yield [k, *chld]
+        return
+
+    @classmethod
+    def filter_compare_superset(cls, obj, target, key_fn=IS, val_fn=IS):
+        if compare_superset(obj, target, key_fn, val_fn):
+            log.debug("found %s %s", obj, target)
+            yield []
+            return
+        log.debug("not-found %s %s", obj, target)
+        for k, v in cls.get_children(obj):
+            for chld in cls.filter_compare_superset(v, target, key_fn, val_fn):
+                yield [k, *chld]
+        return
+
+    @classmethod
     def filter_attr_eq(cls, obj, target):
         if obj == target:
             yield []
@@ -124,6 +286,10 @@ class JsonFind:
     @classmethod
     def find_subset(cls, obj, target):
         return next(cls.filter_subset(obj, target), None)
+
+    @classmethod
+    def find_superset(cls, obj, target):
+        return next(cls.filter_superset(obj, target), None)
 
     @classmethod
     def find_key(cls, obj, target, prev=[]):

--- a/jsonfind/jsonfind.py
+++ b/jsonfind/jsonfind.py
@@ -45,7 +45,7 @@ def compare_regexp(a, b):
     """
     log.debug("compare(regexp) %s %s", a, b)
     if isinstance(a, str):
-        if isinstance(b, re.Pattern):
+        if hasattr(b, "fullmatch"):
             return b.fullmatch(a) is not None
         elif isinstance(b, str):
             return re.fullmatch(b, a) is not None
@@ -66,7 +66,7 @@ def compare_regexp_substr(a, b):
     False
     """
     if isinstance(a, str):
-        if isinstance(b, re.Pattern):
+        if hasattr(b, "search"):
             return b.search(a) is not None
         elif isinstance(b, str):
             return re.search(b, a) is not None


### PR DESCRIPTION
#4 のうち、正規表現には対応。

```
Usage: jsonfind find-any [OPTIONS] [OBJ]

Options:
  --verbose / --no-verbose
  --target TEXT                   query(JSON string)  [required]
  --format [jsonpath|jsonpointer]
  --key [eq|is|match|sub]
  --value [eq|is|match|sub]
  --mode [sub|super|set]
  --help                          Show this message and exit.
```